### PR TITLE
Include Dockerfile.dev and docs to run neuroglancer dev locally

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+# to run locally:
+# docker build -f Dockerfile.dev -t <some-awesome-app-name> .
+# docker run -v $(pwd):/app -p 8080:8080 --rm <some-awesome-app-name>
+
+FROM node:20.11.1
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json for installing dependencies
+COPY package*.json ./
+
+# Install project dependencies
+RUN npm install
+
+# Copy the rest of your app's source code from your host to your image filesystem.
+COPY . .
+
+# Install project dependencies
+# RUN npm i
+
+# Vue CLI serves on port 8080 by default, expose that port
+# EXPOSE 8080
+
+# Command to run the app using npm
+# CMD ["npm", "run", "dev-server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,10 +16,10 @@ RUN npm install
 COPY . .
 
 # Install project dependencies
-# RUN npm i
+RUN npm i
 
 # Vue CLI serves on port 8080 by default, expose that port
-# EXPOSE 8080
+EXPOSE 8080
 
 # Command to run the app using npm
-# CMD ["npm", "run", "dev-server"]
+CMD ["npm", "run", "dev-server"]

--- a/README.md
+++ b/README.md
@@ -187,3 +187,16 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Local Docker development
+
+To control versioning and development on your local machine, please reference the `Dockerfile.dev` as a convenience.
+
+To run the Dockerfile:
+
+```shell
+docker build -f Dockerfile.dev -t <some-awesome-app-name> .
+docker run -v $(pwd):/app -p 8080:8080 --rm <some-awesome-app-name>
+```
+
+Hot-reloading should be present.


### PR DESCRIPTION
@kabilar -- in this PR -- just extracting form https://github.com/lincbrain/neuroglancer/pull/2 the `Dockerfile.dev` aspects that I'd like to preserve for now